### PR TITLE
Send Spark INFO logs to a file in SparkR tests

### DIFF
--- a/R/BUILDING.md
+++ b/R/BUILDING.md
@@ -9,6 +9,5 @@ include Rtools and R in `PATH`.
 `JAVA_HOME` in the system environment variables.
 3. Download and install [Maven](http://maven.apache.org/download.html). Also include the `bin`
 directory in Maven in `PATH`.
-4. Get SparkR source code either using [`git`](http://git-scm.com/downloads) or by downloading a
-source zip from github.
-5. Open a command shell (`cmd`) in the SparkR directory and run `install-dev.bat`
+4. Set `MAVEN_OPTS` as described in [Building Spark](http://spark.apache.org/docs/latest/building-spark.html).
+5. Open a command shell (`cmd`) in the Spark directory and run `mvn -DskipTests -Psparkr package`

--- a/R/log4j.properties
+++ b/R/log4j.properties
@@ -15,17 +15,14 @@
 # limitations under the License.
 #
 
-.First <- function() {
-  home <- Sys.getenv("SPARK_HOME")
-  .libPaths(c(file.path(home, "R", "lib"), .libPaths()))
-  Sys.setenv(NOAWT=1)
+# Set everything to be logged to the file target/unit-tests.log
+log4j.rootCategory=INFO, file
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.append=true
+log4j.appender.file.file=R-unit-tests.log
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n
 
-  require(utils)
-  require(SparkR)
-  sc <- sparkR.init(Sys.getenv("MASTER", unset = ""))
-  assign("sc", sc, envir=.GlobalEnv)
-  sqlCtx <- sparkRSQL.init(sc)
-  assign("sqlCtx", sqlCtx, envir=.GlobalEnv)
-  cat("\n Welcome to SparkR!")
-  cat("\n Spark context is available as sc, SQL context is available as sqlCtx\n")
-}
+# Ignore messages below warning level from Jetty, because it's a bit verbose
+log4j.logger.org.eclipse.jetty=WARN
+org.eclipse.jetty.LEVEL=WARN

--- a/R/run-tests.sh
+++ b/R/run-tests.sh
@@ -20,10 +20,10 @@
 FWDIR="$(cd `dirname $0`; pwd)"
 
 FAILED=0
-LOGFILE=unit-tests.log
+LOGFILE=$FWDIR/R-unit-tests.out
 rm -f $LOGFILE
 
-SPARK_TESTING=1 $FWDIR/../bin/sparkR $FWDIR/pkg/tests/run-all.R >$LOGFILE 2>&1
+SPARK_TESTING=1 $FWDIR/../bin/sparkR --driver-java-options "-Dlog4j.configuration=file:$FWDIR/log4j.properties" $FWDIR/pkg/tests/run-all.R 2>&1 | tee $LOGFILE
 FAILED=$((PIPESTATUS[0]||$FAILED))
 
 if [[ $FAILED != 0 ]]; then

--- a/R/run-tests.sh
+++ b/R/run-tests.sh
@@ -20,10 +20,10 @@
 FWDIR="$(cd `dirname $0`; pwd)"
 
 FAILED=0
-LOGFILE=$FWDIR/R-unit-tests.out
+LOGFILE=$FWDIR/unit-tests.out
 rm -f $LOGFILE
 
-SPARK_TESTING=1 $FWDIR/../bin/sparkR --driver-java-options "-Dlog4j.configuration=file:$FWDIR/log4j.properties" $FWDIR/pkg/tests/run-all.R 2>&1 | tee $LOGFILE
+SPARK_TESTING=1 $FWDIR/../bin/sparkR --driver-java-options "-Dlog4j.configuration=file:$FWDIR/log4j.properties" $FWDIR/pkg/tests/run-all.R 2>&1 | tee -a $LOGFILE
 FAILED=$((PIPESTATUS[0]||$FAILED))
 
 if [[ $FAILED != 0 ]]; then


### PR DESCRIPTION
This changes also keeps the testthat output on the console (and saves it to R-unit-tests.out)

cc @davies 
