### PR TITLE
[SPARKR-241] Update R to fail early if SparkR package is missing

### DIFF
--- a/R/pkg/inst/profile/shell.R
+++ b/R/pkg/inst/profile/shell.R
@@ -20,8 +20,8 @@
   .libPaths(c(file.path(home, "R", "lib"), .libPaths()))
   Sys.setenv(NOAWT=1)
 
-  require(utils)
-  require(SparkR)
+  library(utils)
+  library(SparkR)
   sc <- sparkR.init(Sys.getenv("MASTER", unset = ""))
   assign("sc", sc, envir=.GlobalEnv)
   sqlCtx <- sparkRSQL.init(sc)


### PR DESCRIPTION
R should stop if SparkR is missing.
There is this one case in Spark/R with shell.R.

Please see https://github.com/amplab-extras/SparkR-pkg/pull/233
